### PR TITLE
Update core.py

### DIFF
--- a/esnpy/core.py
+++ b/esnpy/core.py
@@ -22,7 +22,7 @@ class Readout():
         self._from = _from
 
     def _prepare_input(self, reservoir):
-        return np.hstack(map(reservoir.get, self._from))
+        return np.hstack(list(map(reservoir.get, self._from)))
 
     def compute(self, reservoir):
         u = self._prepare_input(reservoir)


### PR DESCRIPTION
Address FutureWarning:
FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.

Addresses Issue:
https://github.com/NiziL/esnpy/issues/1#issue-788393016